### PR TITLE
add a note about permission of ffmpeg binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,6 @@ Code is a rewrite of [`ofxFfmpegRecorder`](https://github.com/Furkanzmc/ofxFFmpe
  - `ffmpeg`  
   By default `ofxFFmpeg` will call `ffmpeg` from your PATH.  
   You may alternatively specify the full path to a local `ffmpeg` binary in `ofxFFmpeg::RecorderSettings`.  
-  `ffmpeg` binaries are included in the `libs` directory for portability.
-
+  `ffmpeg` binaries are included in the `libs` directory for portability.  
+  On macOS and Linux, you may have to give executing permission to `ffmpeg` binary.  
+  by `chmod +x your_ffmpeg_path`


### PR DESCRIPTION
Hi again!

I'm on macOS and I tried to use included `ffmpeg` binary by editing `RecorderSettings::ffmpegPath` but I got an error due to lack of permission.
Users with macOS and Linux may have to do this once before running their applications.

So I think it's better to note about it in README.